### PR TITLE
Fixing start time of the CTF

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -21,7 +21,7 @@ function getTimeUntilDate(date: Date): string {
 }
 
 export function App() {
-    const ctfDate = new Date("May 24, 2024 00:00:00");
+    const ctfDate = new Date("2024-05-24T12:00:00.000Z");
     const [countdown, setCountdown] = useState(getTimeUntilDate(ctfDate));
 
     const backgroundRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
Pushing the start time of the CTF on the ctf.l3ak.team page 14 hours to make it consistent with the actual start date.